### PR TITLE
[버그 수정] 깃헙 배포 후 파비콘이 나타나지 않는 버그 수정

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 	<link rel="stylesheet" href="./css/main.css">  
 
 	<!-- 파비콘 설정 -->
-	<link rel="shortcut icon" href="favicon.ico">
+	<link rel="shortcut icon" href="favicon.ico?">
 
 	<!-- 사이트 이름 설정 -->
 	<title>KCB's Portfolio</title>


### PR DESCRIPTION
- 참고 : https://chinsun9.github.io/2020/09/17/favicon%EC%9D%B4-%EC%95%88%EB%82%98%EC%98%A4%EB%8A%94-%EB%AC%B8%EC%A0%9C/
- 파비콘 URL 부분 맨 뒤에 "?" 문구 추가